### PR TITLE
feat(Nav): Clear chats

### DIFF
--- a/components/ClearChatsButton.tsx
+++ b/components/ClearChatsButton.tsx
@@ -1,0 +1,47 @@
+import React, { useState, MouseEvent } from "react"
+import { IconCheck, IconTrash } from "@tabler/icons-react"
+
+interface Props {
+  clearHandler: () => void
+  classes: {
+    link: string
+    linkIcon: string
+  }
+}
+
+const ClearChatsButton: React.FC<Props> = ({ clearHandler, classes }) => {
+  const [awaitingConfirmation, setAwaitingConfirmation] = useState<boolean>(false)
+
+  const clickHandler = (event: MouseEvent<HTMLAnchorElement>) => {
+    event.preventDefault()
+
+    if (awaitingConfirmation) {
+      clearHandler()
+      setAwaitingConfirmation(false)
+    } else {
+      setAwaitingConfirmation(true)
+    }
+  }
+
+  const cancelConfirmation = () => {
+    setAwaitingConfirmation(false)
+  }
+
+  return (
+    <a href="#" className={classes.link} onClick={clickHandler} onBlur={cancelConfirmation}>
+      {
+        awaitingConfirmation
+          ? <>
+              <IconCheck className={classes.linkIcon} stroke={1.5} />
+              <span>Confirm Clear Chats</span>
+            </>
+          : <>
+              <IconTrash className={classes.linkIcon} stroke={1.5} />
+              <span>Clear Chats</span>
+            </>
+      }
+    </a>
+  )
+}
+
+export default ClearChatsButton

--- a/components/Nav.tsx
+++ b/components/Nav.tsx
@@ -134,6 +134,7 @@ export default function NavbarSimple() {
 
   const addChat = useChatStore((state) => state.addChat);
   const deleteChat = useChatStore((state) => state.deleteChat);
+  const clearChats = useChatStore((state) => state.clearChats);
 
   const chats = useChatStore((state) => state.chats);
   const setActiveChat = useChatStore((state) => state.setActiveChat);
@@ -300,6 +301,18 @@ export default function NavbarSimple() {
         </Navbar.Section>
       </MediaQuery>
       <Navbar.Section className={classes.footer}>
+        <a
+            href="#"
+            className={classes.link}
+            onClick={() => {
+              clearChats()
+              addChat()
+            }}
+        >
+          <IconTrash className={classes.linkIcon} stroke={1.5} />
+          <span>Clear Chats</span>
+        </a>
+
         <a
           href="#"
           className={classes.link}

--- a/components/Nav.tsx
+++ b/components/Nav.tsx
@@ -304,7 +304,8 @@ export default function NavbarSimple() {
         <a
             href="#"
             className={classes.link}
-            onClick={() => {
+            onClick={(event) => {
+              event.preventDefault()
               clearChats()
               addChat()
             }}

--- a/components/Nav.tsx
+++ b/components/Nav.tsx
@@ -28,6 +28,7 @@ import {
   IconTrash,
 } from "@tabler/icons-react";
 import { useRef, useState } from "react";
+import ClearChatsButton from "./ClearChatsButton";
 import KeyModal from "./KeyModal";
 import SettingsModal from "./SettingsModal";
 
@@ -301,18 +302,13 @@ export default function NavbarSimple() {
         </Navbar.Section>
       </MediaQuery>
       <Navbar.Section className={classes.footer}>
-        <a
-            href="#"
-            className={classes.link}
-            onClick={(event) => {
-              event.preventDefault()
+        <ClearChatsButton
+            classes={classes}
+            clearHandler={() => {
               clearChats()
               addChat()
             }}
-        >
-          <IconTrash className={classes.linkIcon} stroke={1.5} />
-          <span>Clear Chats</span>
-        </a>
+        />
 
         <a
           href="#"

--- a/stores/ChatStore.ts
+++ b/stores/ChatStore.ts
@@ -45,6 +45,7 @@ interface ChatState {
 
   addChat: (title?: string) => void;
   deleteChat: (id: string) => void;
+  clearChats: () => void;
   setActiveChat: (id: string) => void;
   pushMessage: (message: Message) => void;
   delMessage: (message: Message) => void;
@@ -107,6 +108,7 @@ export const useChatStore = create<ChatState>()(
   persist(
     (set, get) => ({
       ...initialState,
+      clearChats: () => set(() => ({ chats: [], activeChatId: undefined })),
       deleteChat: (id: string) =>
         set((state) => ({
           chats: state.chats.filter((chat) => chat.id !== id),


### PR DESCRIPTION
Add the ability to clear chats, similar to clear conversations in ChatGPT.

Intentional difference is that clear is always shown instead of hidden until a chat exists.

|ChatGPT version|PR version|
|---|---|
|![image](https://user-images.githubusercontent.com/3478672/229258622-ae70a3c9-657e-4888-97da-0972c0a1ec27.png)|![image](https://user-images.githubusercontent.com/3478672/229258638-9ec9d86c-afb2-4cc2-b0e7-6af67064ca04.png)|

