### PR TITLE
add ability to insert .env.local api key

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ Congratulations! 🎉 You are now running YakGPT locally on your machine.
 
 To utilize YakGPT, you'll need to acquire an API key for OpenAI. The app should prompt you to insert you key.
 
+### Add to .env.local
+
+If you want the key to persist across app builds, you can add it to the .env.local.
+
+`echo "NEXT_PUBLIC_OPENAI_API_KEY=<your-open-ai-key-here>" > .env.local`
+
 ## 🐳 Docker
 
 To build a Docker image, run:

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Congratulations! 🎉 You are now running YakGPT locally on your machine.
 
 To utilize YakGPT, you'll need to acquire an API key for OpenAI. The app should prompt you to insert you key.
 
-### Add to .env.local
+### Add to .env.local(⚠️ Local use only)
 
 If you want the key to persist across app builds, you can add it to the .env.local.
 

--- a/stores/ChatStore.ts
+++ b/stores/ChatStore.ts
@@ -83,7 +83,7 @@ const initialChatId = uuidv4();
 
 const initialState = {
   apiState: "idle" as APIState,
-  apiKey: undefined,
+  apiKey: process.env.NEXT_PUBLIC_OPENAI_API_KEY || undefined,
   chats: [
     {
       id: initialChatId,


### PR DESCRIPTION
Hey yak folks! I love this tool and just had a thought as I was starting to use it. The prompting for api key every time I would change the port for which I serve the app was getting annoying so given it's a NextJS app I thought I could point the apiKey reads from the store to pull from a NEXT_PUBLIC_ENV variable in the .env.local. 

This PR adds those changes and some guidance in the README.