### PR TITLE
fix(ChatTextInput): prevent sending message on Enter press in IME composing mode.

### DIFF
--- a/components/ChatTextInput.tsx
+++ b/components/ChatTextInput.tsx
@@ -49,7 +49,11 @@ export default function ChatInput() {
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
     event.stopPropagation();
-    if (event.key === "Enter" && !event.shiftKey) {
+    if (
+      !event.nativeEvent.isComposing &&
+      event.key === "Enter" &&
+      !event.shiftKey
+    ) {
       event.preventDefault();
       doSubmit();
     }


### PR DESCRIPTION
When using some Asian input method editor, the Enter key has a special usage during composing.
Incomplete message is suddenly sent while typing a long message.

reference: [KeyboardEvent.isComposing](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/isComposing)