### PR TITLE
Bug fix/feat: edit button

### DIFF
--- a/components/ChatMessage.tsx
+++ b/components/ChatMessage.tsx
@@ -167,15 +167,14 @@ export default function ChatDisplay({ message }: { message: Message }) {
               className={classes.messageDisplay}
             />
           </div>
-          {!(message.role !== "assistant" && pushToTalkMode) && (
-            <ActionIcon
-              className={cx(classes.actionIcon, classes.topOfMessage)}
-              onClick={() => handleMainAction(message)}
-              color="gray"
-            >
-              {message.role === "assistant" ? <IconRepeat /> : <IconEdit />}
-            </ActionIcon>
-          )}
+
+          <ActionIcon
+            className={cx(classes.actionIcon, classes.topOfMessage)}
+            onClick={() => handleMainAction(message)}
+            color="gray"
+          >
+            {message.role === "assistant" ? <IconRepeat /> : <IconEdit />}
+          </ActionIcon>
         </div>
       </div>
     </div>

--- a/components/UIController.tsx
+++ b/components/UIController.tsx
@@ -109,12 +109,18 @@ const ChatInput = () => {
 
   const router = useRouter();
 
+  const editingMessage = useChatStore((state) => state.editingMessage);
+
   const pushToTalkMode = useChatStore((state) => state.pushToTalkMode);
   const audioState = useChatStore((state) => state.audioState);
 
   const activeChatId = useChatStore((state) => state.activeChatId);
   const showTextDuringPTT = useChatStore((state) => state.showTextDuringPTT);
-  const showTextInput = !pushToTalkMode || showTextDuringPTT;
+  const showTextInput = !pushToTalkMode || showTextDuringPTT || editingMessage;
+
+  console.log("!pushToTalkMode :>> ", !pushToTalkMode);
+  console.log("showTextDuringPTT :>> ", showTextDuringPTT);
+  console.log("editingMessage :>> ", editingMessage);
 
   const modelChoiceSTT = useChatStore((state) => state.modelChoiceSTT);
   const Recorder = modelChoiceSTT === "azure" ? AzureRecorder : OpusRecorder;


### PR DESCRIPTION
I'm not sure why the ChatMassage edit button depended on `pushToTalkMode`, since it's just the microphone button showing. Maybe it should have been dependent on 'Show input next to mic' which would make sense since you could argue that the user won't be typing and therefore can't edit messages, but maybe I'm missing something.

I think it's more intuitive to have the delete button always showing and shrink the microphone button when the user wants to edit a message.

#### Before
https://user-images.githubusercontent.com/7318830/230712992-7f60eb18-225d-42b4-b50f-8552af68be68.mov

#### After
https://user-images.githubusercontent.com/7318830/230713001-babea154-df58-4822-b019-5042964d711a.mov

