### PR TITLE
More natural hands-free conversation by debouncing message submit (Azure only to start)

### DIFF
--- a/components/SettingsModal.tsx
+++ b/components/SettingsModal.tsx
@@ -10,6 +10,7 @@ import {
   Tabs,
   Autocomplete,
   Switch,
+  NumberInput,
   px,
   Accordion,
   Title,
@@ -328,6 +329,15 @@ export default function SettingsModal({ close }: { close: () => void }) {
                 form.setFieldValue("spoken_language_azure", value!);
               }}
               data={Object.values(azureCandidateLanguages)}
+            />
+            <NumberInput
+              label="Message submit debounce (milliseconds)"
+              value={form.values.submit_debounce_ms}
+              onChange={(value) => {
+                if (typeof value === "number") {
+                  form.setFieldValue("submit_debounce_ms", value);
+                }
+              }}
             />
             <Title pt="md" pb="sm" order={4}>
               Text to Speech

--- a/stores/ChatStore.ts
+++ b/stores/ChatStore.ts
@@ -52,6 +52,7 @@ interface SettingsForm {
   spoken_language_azure: string;
   spoken_language_code_azure: string;
   spoken_language_style: string;
+  submit_debounce_ms: number;
 }
 
 export const defaultSettings = {
@@ -77,6 +78,7 @@ export const defaultSettings = {
   spoken_language_azure: "English (US)",
   spoken_language_code_azure: "en-US",
   spoken_language_style: "friendly",
+  submit_debounce_ms: 0,
 };
 
 export interface ChatState {


### PR DESCRIPTION
This addition attempts to improve the app's speech-to-text interface through Azure by allowing users to continue talking naturally with pauses. 

When the new setting has a non-zero value, the transcription accumulates in the chat input, and messages are submitted only after the maximum pause length has elapsed. This duration is configurable in Azure STT settings, and defaults to 0 (equivalent to original behavior).

I'm keen to help improve the hands-free experience of the app in any way that I can. Hope you find this addition useful.