### PR TITLE
Fix cost calculation for GPT-4

### DIFF
--- a/stores/Chat.ts
+++ b/stores/Chat.ts
@@ -6,6 +6,7 @@ export interface Chat {
   messages: Message[];
   chosenCharacter?: string | undefined;
   createdAt?: Date | undefined;
-  tokensUsed?: number;
+  promptTokensUsed?: number;
+  completionTokensUsed?: number;
   costIncurred?: number;
 }

--- a/stores/Model.ts
+++ b/stores/Model.ts
@@ -3,23 +3,23 @@ export const modelInfos: Record<
   {
     displayName: string;
     maxTokens: number;
-    costPer1kTokens: number;
+    costPer1kTokens: { prompt: number; completion: number };
   }
 > = {
   "gpt-3.5-turbo": {
     displayName: "ChatGPT-3.5",
     maxTokens: 4096,
-    costPer1kTokens: 0.002,
+    costPer1kTokens: { prompt: 0.002, completion: 0.002 },
   },
   "gpt-3.5-turbo-0301": {
     displayName: "ChatGPT-3.5 March 1",
     maxTokens: 4096,
-    costPer1kTokens: 0.002,
+    costPer1kTokens: { prompt: 0.002, completion: 0.002 },
   },
   "gpt-4": {
     displayName: "GPT-4",
     maxTokens: 8192,
-    costPer1kTokens: 0.06,
+    costPer1kTokens: { prompt: 0.03, completion: 0.06 },
   },
 };
 
@@ -27,5 +27,5 @@ export const getModelInfo = (model: string) =>
   modelInfos[model] || {
     displayName: model,
     maxTokens: 4096,
-    costPer1kTokens: 0.0,
+    costPer1kTokens: {prompt: 0, completion: 0},
   };

--- a/stores/OpenAI.ts
+++ b/stores/OpenAI.ts
@@ -196,7 +196,7 @@ export async function streamCompletion(
       );
 
       const completionTokensUsed = countTokens(
-        [...loadingMessages.map((m) => m.content), buffer].join("\n")
+        loadingMessages.map((m) => m.content).join("\n") + buffer
       );
 
       endCallback?.(promptTokensUsed, completionTokensUsed);

--- a/stores/OpenAI.ts
+++ b/stores/OpenAI.ts
@@ -1,3 +1,4 @@
+import _ from "lodash";
 import { IncomingMessage } from "http";
 import https from "https";
 import { Message, truncateMessages, countTokens } from "./Message";
@@ -118,7 +119,9 @@ export async function streamCompletion(
   apiKey: string,
   abortController?: AbortController,
   callback?: ((res: IncomingMessage) => void) | undefined,
-  endCallback?: ((tokensUsed: number) => void) | undefined,
+  endCallback?:
+    | ((promptTokensUsed: number, completionTokensUsed: number) => void)
+    | undefined,
   errorCallback?: ((res: IncomingMessage, body: string) => void) | undefined
 ) {
   const modelInfo = getModelInfo(params.model);
@@ -151,7 +154,7 @@ export async function streamCompletion(
     res.on("data", (chunk) => {
       if (abortController?.signal.aborted) {
         res.destroy();
-        endCallback?.(0);
+        endCallback?.(0, 0);
         return;
       }
 
@@ -184,11 +187,19 @@ export async function streamCompletion(
     });
 
     res.on("end", () => {
-      const tokensUsed =
-        countTokens(submitMessages.map((m) => m.content).join("\n")) +
-        countTokens(buffer);
+      const [loadingMessages, loadedMessages] = _.partition(
+        submitMessages,
+        "loading"
+      );
+      const promptTokensUsed = countTokens(
+        loadedMessages.map((m) => m.content).join("\n")
+      );
 
-      endCallback?.(tokensUsed);
+      const completionTokensUsed = countTokens(
+        loadingMessages.map((m) => m.content).join("\n")
+      );
+
+      endCallback?.(promptTokensUsed, completionTokensUsed);
     });
   };
 

--- a/stores/OpenAI.ts
+++ b/stores/OpenAI.ts
@@ -196,7 +196,7 @@ export async function streamCompletion(
       );
 
       const completionTokensUsed = countTokens(
-        loadingMessages.map((m) => m.content).join("\n")
+        [...loadingMessages.map((m) => m.content), buffer].join("\n")
       );
 
       endCallback?.(promptTokensUsed, completionTokensUsed);


### PR DESCRIPTION
Responding to [this issue](https://github.com/yakGPT/yakGPT/issues/72). GPT-4 is unique in that it bills differently for prompt tokens vs the generated tokens.

This PR adds logic to distinguish between prompt tokens and completion tokens when calculating a chat's cost. 
