### PR TITLE
Auto-save chats as markdown files to local directory

### DIFF
--- a/components/SettingsModal.tsx
+++ b/components/SettingsModal.tsx
@@ -17,7 +17,7 @@ import {
 } from "@mantine/core";
 import ISO6391 from "iso-639-1";
 import { useForm } from "@mantine/form";
-import { IconBraces, IconMicrophone, IconSettings } from "@tabler/icons-react";
+import { IconBraces, IconFolderDown, IconMicrophone, IconSettings } from "@tabler/icons-react";
 import { useEffect, useState } from "react";
 import * as ElevenLabs from "@/stores/ElevenLabs";
 import { refreshModels, updateSettingsForm } from "@/stores/ChatActions";
@@ -138,6 +138,9 @@ export default function SettingsModal({ close }: { close: () => void }) {
             </Tabs.Tab>
             <Tabs.Tab value="11labs" icon={<IconBraces size={px("0.8rem")} />}>
               ElevenLabs
+            </Tabs.Tab>
+            <Tabs.Tab value="storage" icon={<IconFolderDown size={px("0.8rem")} />}>
+              Storage
             </Tabs.Tab>
           </Tabs.List>
           <Tabs.Panel value="openai" pt="xs">
@@ -403,6 +406,25 @@ export default function SettingsModal({ close }: { close: () => void }) {
                 value: voice.voice_id,
               }))}
             ></Select>
+          </Tabs.Panel>
+          <Tabs.Panel value="storage" pt="xs">
+            <Switch
+              checked={form.values.enable_local_storage}
+              label="Enable local file storage to automatically save chats as markdown files"
+              pt="xs" mb="md"
+              onChange={(event) => {
+                form.setFieldValue(
+                  "enable_local_storage",
+                  event.currentTarget.checked
+                );
+              }}
+            />
+            <TextInput
+              label="Local storage directory (absolute path)"
+              placeholder="Enter a directory path"
+              mt="md"
+              {...form.getInputProps("local_storage_dirpath")}
+            />
           </Tabs.Panel>
           <Group position="apart" mt="lg">
             <Button

--- a/pages/api/saveChatToFile.js
+++ b/pages/api/saveChatToFile.js
@@ -1,0 +1,26 @@
+import fs from 'fs';
+import path from 'path';
+
+export default function handler(req, res) {
+  const { dirPath, id, role, message } = req.body;
+
+  const fileName = `${id}.md`.replace(/\:/g, '-');
+  const filePath = path.join(dirPath, fileName);
+  const formattedMessage = `**${role}**:\n\n${message}\n\n`;
+
+  // Make sure the '/chats' directory exists
+  if (!fs.existsSync(dirPath)) {
+    fs.mkdirSync(dirPath);
+  }
+
+  // Write to the markdown file
+  fs.appendFile(filePath, formattedMessage, function (err) {
+    if (err) {
+      console.log(err);
+      res.status(500).json({ message: 'Error writing to file' });
+    } else {
+      console.log(`The message was saved to ${filePath}`);
+      res.status(200).json({ message: 'Successfully wrote to file' });
+    }
+  });
+}

--- a/stores/ChatStore.ts
+++ b/stores/ChatStore.ts
@@ -57,6 +57,9 @@ interface SettingsForm {
   spoken_language_code_azure: string;
   spoken_language_style: string;
   submit_debounce_ms: number;
+  // Storage
+  enable_local_storage: boolean;
+  local_storage_dirpath: string;
 }
 
 export const defaultSettings = {
@@ -86,6 +89,9 @@ export const defaultSettings = {
   spoken_language_code_azure: "en-US",
   spoken_language_style: "friendly",
   submit_debounce_ms: 0,
+  // Storage
+  enable_local_storage: false,
+  local_storage_dirpath: "/Users/me/Documents/YakGPT",
 };
 
 export interface ChatState {


### PR DESCRIPTION
Thank you for creating yakGPT! This PR adds an off-by-default user preference to allow chats to be automatically saved to a local directory as markdown files. I find it useful to be able to quickly refer back to chats through search.

Screenshot of the settings UI added:

<img width="471" alt="Screenshot 2024-03-13 at 11 44 46 AM" src="https://github.com/yakGPT/yakGPT/assets/352089/5c0fccbc-9304-48ee-a829-5652a73c0cf5">

I've manually tested and verified these two preferences to work locally. This doesn't consider cloud-hosted installations (and likely won't work), so perhaps it should be only visible if the hostname is localhost - if there's interest in merging this, I can add that change.

This uses the createdAt date string as a filename. That works for me since I don't really care about the title, but a possible enhancement would be appending the chat title to the file to make the directory more browseable.